### PR TITLE
#35 car turning math

### DIFF
--- a/src/main/java/hu/oe/nik/szfmv/automatedcar/engine/CarAxisParams.java
+++ b/src/main/java/hu/oe/nik/szfmv/automatedcar/engine/CarAxisParams.java
@@ -2,11 +2,11 @@ package hu.oe.nik.szfmv.automatedcar.engine;
 
 public interface CarAxisParams {
 
-    int getCarWidthPixel() ;
+    int getCarWidthPixel();
 
-   int getAxisLengthPixel();
+    int getAxisLengthPixel();
 
-   int getMaxTurningPercent();
+    int getMaxTurningPercent();
 
 
 }

--- a/src/main/java/hu/oe/nik/szfmv/automatedcar/engine/CarAxisParams.java
+++ b/src/main/java/hu/oe/nik/szfmv/automatedcar/engine/CarAxisParams.java
@@ -1,0 +1,12 @@
+package hu.oe.nik.szfmv.automatedcar.engine;
+
+public interface CarAxisParams {
+
+    int getCarWidthPixel() ;
+
+   int getAxisLengthPixel();
+
+   int getMaxTurningPercent();
+
+
+}

--- a/src/main/java/hu/oe/nik/szfmv/automatedcar/engine/CarAxisParams.java
+++ b/src/main/java/hu/oe/nik/szfmv/automatedcar/engine/CarAxisParams.java
@@ -2,11 +2,19 @@ package hu.oe.nik.szfmv.automatedcar.engine;
 
 public interface CarAxisParams {
 
+    /**
+     * @return car width in pixel
+     */
     int getCarWidthPixel();
 
+    /**
+     * @return axis legth in pixel
+     */
     int getAxisLengthPixel();
 
-    int getMaxTurningPercent();
-
+    /**
+     * @return magic number to calculation meter
+     */
+    int getPixelToMeter();
 
 }

--- a/src/main/java/hu/oe/nik/szfmv/automatedcar/engine/CarAxisParamsImpl.java
+++ b/src/main/java/hu/oe/nik/szfmv/automatedcar/engine/CarAxisParamsImpl.java
@@ -1,0 +1,25 @@
+package hu.oe.nik.szfmv.automatedcar.engine;
+
+public class CarAxisParamsImpl implements CarAxisParams {
+
+    final int carWidthPixel=90;
+    final int axisLengthPixel=130;
+    final int maxTurningPercent=60;
+
+    @Override
+    public int getCarWidthPixel() {
+        return carWidthPixel;
+    }
+
+    @Override
+    public int getAxisLengthPixel() {
+        return axisLengthPixel;
+    }
+
+    @Override
+    public int getMaxTurningPercent() {
+        return maxTurningPercent;
+    }
+
+
+}

--- a/src/main/java/hu/oe/nik/szfmv/automatedcar/engine/CarAxisParamsImpl.java
+++ b/src/main/java/hu/oe/nik/szfmv/automatedcar/engine/CarAxisParamsImpl.java
@@ -2,9 +2,9 @@ package hu.oe.nik.szfmv.automatedcar.engine;
 
 public class CarAxisParamsImpl implements CarAxisParams {
 
-    final int carWidthPixel=90;
-    final int axisLengthPixel=130;
-    final int maxTurningPercent=60;
+    final int carWidthPixel = 90;
+    final int axisLengthPixel = 130;
+    final int maxTurningPercent = 60;
 
     @Override
     public int getCarWidthPixel() {

--- a/src/main/java/hu/oe/nik/szfmv/automatedcar/engine/CarAxisParamsImpl.java
+++ b/src/main/java/hu/oe/nik/szfmv/automatedcar/engine/CarAxisParamsImpl.java
@@ -2,9 +2,11 @@ package hu.oe.nik.szfmv.automatedcar.engine;
 
 public class CarAxisParamsImpl implements CarAxisParams {
 
+
+
+    final int pixelToMeter = 50;
     final int carWidthPixel = 90;
     final int axisLengthPixel = 130;
-    final int maxTurningPercent = 60;
 
     @Override
     public int getCarWidthPixel() {
@@ -17,9 +19,8 @@ public class CarAxisParamsImpl implements CarAxisParams {
     }
 
     @Override
-    public int getMaxTurningPercent() {
-        return maxTurningPercent;
+    public int getPixelToMeter() {
+        return pixelToMeter;
     }
-
 
 }

--- a/src/main/java/hu/oe/nik/szfmv/automatedcar/engine/TurningHandler.java
+++ b/src/main/java/hu/oe/nik/szfmv/automatedcar/engine/TurningHandler.java
@@ -5,14 +5,18 @@ public class TurningHandler {
 
     CarAxisParams carAxisParams;
 
-
     public TurningHandler() {
         this.carAxisParams = new CarAxisParamsImpl();
     }
 
-    public double angularVelocityCalculation(final int steeringWheelState,int speed)
-    {
-        if (steeringWheelState==0) {
+    /**
+     * Calculate new angular velocity(/speed)
+     * @param steeringWheelState steering wheel state [-60,60]
+     * @param speed car actual speed
+     * @return current angular velocity
+     */
+    public double angularVelocityCalculation(final int steeringWheelState, int speed) {
+        if (steeringWheelState == 0) {
             return 0;
         } else {
             return speed / turningCircleCalculation(steeringWheelState);
@@ -20,9 +24,8 @@ public class TurningHandler {
     }
 
 
-    private double turningCircleCalculation(final int steeringWheelState)
-    {
-        return (carAxisParams.getAxisLengthPixel()/ Math.tan(Math.toRadians(steeringWheelState))+carAxisParams.getCarWidthPixel())/50;
+    private double turningCircleCalculation(final int steeringWheelState) {
+        return (carAxisParams.getAxisLengthPixel() / Math.tan(Math.toRadians(steeringWheelState)) + carAxisParams.getCarWidthPixel()) / 50;
     }
 
 

--- a/src/main/java/hu/oe/nik/szfmv/automatedcar/engine/TurningHandler.java
+++ b/src/main/java/hu/oe/nik/szfmv/automatedcar/engine/TurningHandler.java
@@ -28,7 +28,10 @@ public class TurningHandler {
 
 
     private double turningCircleCalculation(final int steeringWheelState) {
-        return (carAxisParams.getAxisLengthPixel() / Math.tan(Math.toRadians(steeringWheelState)) + carAxisParams.getCarWidthPixel()) / carAxisParams.getPixelToMeter();
+        return (carAxisParams.getAxisLengthPixel()
+                / Math.tan(Math.toRadians(steeringWheelState))
+                + carAxisParams.getCarWidthPixel())
+                / carAxisParams.getPixelToMeter();
     }
 
 

--- a/src/main/java/hu/oe/nik/szfmv/automatedcar/engine/TurningHandler.java
+++ b/src/main/java/hu/oe/nik/szfmv/automatedcar/engine/TurningHandler.java
@@ -5,6 +5,9 @@ public class TurningHandler {
 
     CarAxisParams carAxisParams;
 
+    /**
+     * turning handler constructor inicialize car axis params
+     */
     public TurningHandler() {
         this.carAxisParams = new CarAxisParamsImpl();
     }
@@ -25,7 +28,7 @@ public class TurningHandler {
 
 
     private double turningCircleCalculation(final int steeringWheelState) {
-        return (carAxisParams.getAxisLengthPixel() / Math.tan(Math.toRadians(steeringWheelState)) + carAxisParams.getCarWidthPixel()) / 50;
+        return (carAxisParams.getAxisLengthPixel() / Math.tan(Math.toRadians(steeringWheelState)) + carAxisParams.getCarWidthPixel()) / carAxisParams.getPixelToMeter();
     }
 
 

--- a/src/main/java/hu/oe/nik/szfmv/automatedcar/engine/TurningHandler.java
+++ b/src/main/java/hu/oe/nik/szfmv/automatedcar/engine/TurningHandler.java
@@ -1,0 +1,29 @@
+package hu.oe.nik.szfmv.automatedcar.engine;
+
+public class TurningHandler {
+
+
+    CarAxisParams carAxisParams;
+
+
+    public TurningHandler() {
+        this.carAxisParams = new CarAxisParamsImpl();
+    }
+
+    public double angularVelocityCalculation(final int steeringWheelState,int speed)
+    {
+        if (steeringWheelState==0) {
+            return 0;
+        } else {
+            return speed / turningCircleCalculation(steeringWheelState);
+        }
+    }
+
+
+    private double turningCircleCalculation(final int steeringWheelState)
+    {
+        return (carAxisParams.getAxisLengthPixel()/ Math.tan(Math.toRadians(steeringWheelState))+carAxisParams.getCarWidthPixel())/50;
+    }
+
+
+}

--- a/src/main/java/hu/oe/nik/szfmv/automatedcar/systemcomponents/SteeringSystem.java
+++ b/src/main/java/hu/oe/nik/szfmv/automatedcar/systemcomponents/SteeringSystem.java
@@ -26,6 +26,11 @@ public class SteeringSystem extends SystemComponent {
         //TODO
     }
 
+    /**
+     * update angular speed
+     * @param steeringWheelState actual steering wheel state
+     * @param speed actual speed
+     */
     public void updateAngularSpeed(final int steeringWheelState, final int speed) {
         angularSpeed = turningHandler.angularVelocityCalculation(steeringWheelState, speed);
     }

--- a/src/main/java/hu/oe/nik/szfmv/automatedcar/systemcomponents/SteeringSystem.java
+++ b/src/main/java/hu/oe/nik/szfmv/automatedcar/systemcomponents/SteeringSystem.java
@@ -1,12 +1,15 @@
 package hu.oe.nik.szfmv.automatedcar.systemcomponents;
 
 import hu.oe.nik.szfmv.automatedcar.bus.VirtualFunctionBus;
+import hu.oe.nik.szfmv.automatedcar.engine.TurningHandler;
 
 /**
  * Steering system is responsible for the turning of the car.
  */
 public class SteeringSystem extends SystemComponent {
     private double angularSpeed = 0;
+    private TurningHandler turningHandler;
+
 
     /**
      * Creates a steering system that connects the Virtual Function Bus
@@ -15,11 +18,17 @@ public class SteeringSystem extends SystemComponent {
      */
     public SteeringSystem(VirtualFunctionBus virtualFunctionBus) {
         super(virtualFunctionBus);
+        turningHandler=new TurningHandler();
     }
 
     @Override
     public void loop() {
-        // TODO
+    //TODO
+    }
+
+    public void updateAngularSpeed(final int steeringWheelState,final int speed)
+    {
+           angularSpeed = turningHandler.angularVelocityCalculation(steeringWheelState,speed);
     }
 
     public double getAngularSpeed() {

--- a/src/main/java/hu/oe/nik/szfmv/automatedcar/systemcomponents/SteeringSystem.java
+++ b/src/main/java/hu/oe/nik/szfmv/automatedcar/systemcomponents/SteeringSystem.java
@@ -18,17 +18,16 @@ public class SteeringSystem extends SystemComponent {
      */
     public SteeringSystem(VirtualFunctionBus virtualFunctionBus) {
         super(virtualFunctionBus);
-        turningHandler=new TurningHandler();
+        turningHandler = new TurningHandler();
     }
 
     @Override
     public void loop() {
-    //TODO
+        //TODO
     }
 
-    public void updateAngularSpeed(final int steeringWheelState,final int speed)
-    {
-           angularSpeed = turningHandler.angularVelocityCalculation(steeringWheelState,speed);
+    public void updateAngularSpeed(final int steeringWheelState, final int speed) {
+        angularSpeed = turningHandler.angularVelocityCalculation(steeringWheelState, speed);
     }
 
     public double getAngularSpeed() {

--- a/src/test/java/hu/oe/nik/szfmv/engine/TurningHandlerTest.java
+++ b/src/test/java/hu/oe/nik/szfmv/engine/TurningHandlerTest.java
@@ -1,0 +1,29 @@
+package hu.oe.nik.szfmv.engine;
+
+import hu.oe.nik.szfmv.automatedcar.bus.VirtualFunctionBus;
+import hu.oe.nik.szfmv.automatedcar.systemcomponents.SteeringSystem;
+import junitparams.JUnitParamsRunner;
+import junitparams.Parameters;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(JUnitParamsRunner.class)
+public class TurningHandlerTest {
+
+    private SteeringSystem underTest;
+
+    @Before
+    public void setUp() {
+        underTest = new SteeringSystem(new VirtualFunctionBus());
+    }
+
+    @Test
+    @Parameters({ "30|15|2", "60|50|15", "45|70|16", "0|10|0" })
+    public void angularVelocityCalculationTest(final int steeringWheelState,int speed,long angularVelocityResult)
+    {
+        underTest.updateAngularSpeed(steeringWheelState,speed);
+        Assert.assertEquals(Math.round(underTest.getAngularSpeed()),angularVelocityResult);
+    }
+}


### PR DESCRIPTION
Summary of changes and the sender team

The irrelevant parts must be removed!

# Fixed bugs (with referenced issue)

 - Egocar now turns left pressing left arrow #ISSUE-ID
 - ...

# Added functionalities (with referenced issue)

 - Flux capacitor has been implemented #ISSUE-ID
 - ...

# (Breaking) changes (with referenced issue)

 - getWorldObjectReferencePoint no longer returns the top-left corner
   but the centroid #ISSUE-ID
 - ...

# Other (test, documentation addition, refactor)

 - e.g. Tests added to powertrain
 - Input handling was refactored
 - ...
